### PR TITLE
Fix quantity rules when variant is switched (#2251)

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1786,7 +1786,7 @@ details[open] > .share-button__fallback {
 .customer select {
   cursor: pointer;
   line-height: calc(1 + 0.6 / var(--font-body-scale));
-  padding: 0 2rem;
+  padding: 0 calc(var(--inputs-border-width) + 3rem) 0 2rem;
   margin: var(--inputs-border-width);
   min-height: calc(var(--inputs-border-width) * 2);
 }

--- a/assets/cart.js
+++ b/assets/cart.js
@@ -100,6 +100,7 @@ class CartItems extends HTMLElement {
       .then((state) => {
         const parsedState = JSON.parse(state);
         const quantityElement = document.getElementById(`Quantity-${line}`) || document.getElementById(`Drawer-quantity-${line}`);
+        const items = document.querySelectorAll('.cart-item');
 
         if (parsedState.errors) {
           quantityElement.value = quantityElement.getAttribute('value');
@@ -120,8 +121,15 @@ class CartItems extends HTMLElement {
           elementToReplace.innerHTML = 
             this.getSectionInnerHTML(parsedState.sections[section.section], section.selector);
         }));
-        const updatedValue = parsedState.items[line - 1].quantity;
-        const message = updatedValue !== parseInt(quantityElement.value) ? window.cartStrings.quantityError.replace('[quantity]', updatedValue) : '';
+        const updatedValue = parsedState.items[line - 1] ? parsedState.items[line - 1].quantity : undefined;
+        let message = '';
+        if (items.length === parsedState.items.length && updatedValue !== parseInt(quantityElement.value)) {
+          if (typeof updatedValue === 'undefined') {
+            message = window.cartStrings.error;
+          } else {
+            message = window.cartStrings.quantityError.replace('[quantity]', updatedValue);
+          }
+        }
         this.updateLiveRegions(line, message);
 
         const lineItem = document.getElementById(`CartItem-${line}`) || document.getElementById(`CartDrawer-Item-${line}`);
@@ -145,7 +153,7 @@ class CartItems extends HTMLElement {
 
   updateLiveRegions(line, message) {
     const lineItemError = document.getElementById(`Line-item-error-${line}`) || document.getElementById(`CartDrawer-LineItemError-${line}`);
-    lineItemError.querySelector('.cart-item__error-text').innerHTML = message;
+    if (lineItemError) lineItemError.querySelector('.cart-item__error-text').innerHTML = message;
 
     this.lineItemStatusElement.setAttribute('aria-hidden', true);
 

--- a/assets/constants.js
+++ b/assets/constants.js
@@ -2,5 +2,6 @@ const ON_CHANGE_DEBOUNCE_TIMER = 300;
 
 const PUB_SUB_EVENTS = {
   cartUpdate: 'cart-update',
-  quantityUpdate: 'quantity-update' 
+  quantityUpdate: 'quantity-update',
+  variantChange: 'variant-change'
 };

--- a/assets/global.js
+++ b/assets/global.js
@@ -906,6 +906,7 @@ class VariantSelects extends HTMLElement {
 
   renderProductInfo() {
     const requestedVariantId = this.currentVariant.id;
+    const sectionId = this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section;
 
     fetch(`${this.dataset.url}?variant=${requestedVariantId}&section_id=${this.dataset.originalSection ? this.dataset.originalSection : this.dataset.section}`)
       .then((response) => response.text())
@@ -934,7 +935,14 @@ class VariantSelects extends HTMLElement {
 
         if (inventoryDestination) inventoryDestination.classList.toggle('visibility-hidden', inventorySource.innerText === '');
 
-        this.toggleAddButton(!this.currentVariant.available, window.variantStrings.soldOut);
+        const addButtonUpdated = html.getElementById(`ProductSubmitButton-${sectionId}`);
+        this.toggleAddButton(addButtonUpdated ? addButtonUpdated.hasAttribute('disabled') : true, window.variantStrings.soldOut);
+
+        publish(PUB_SUB_EVENTS.variantChange, {data: {
+          sectionId,
+          html,
+          variant: this.currentVariant
+        }});
       });
   }
 

--- a/assets/quick-add.js
+++ b/assets/quick-add.js
@@ -81,8 +81,8 @@ if (!customElements.get('quick-add-modal')) {
     preventDuplicatedIDs() {
       const sectionId = this.productElement.dataset.section;
       this.productElement.innerHTML = this.productElement.innerHTML.replaceAll(sectionId, `quickadd-${ sectionId }`);
-      this.productElement.querySelectorAll('variant-selects, variant-radios').forEach((variantSelect) => {
-        variantSelect.dataset.originalSection = sectionId;
+      this.productElement.querySelectorAll('variant-selects, variant-radios, product-info').forEach((element) => {
+        element.dataset.originalSection = sectionId;
       });
     }
 

--- a/sections/featured-product.liquid
+++ b/sections/featured-product.liquid
@@ -190,6 +190,7 @@
                 </p>
               {%- when 'quantity_selector' -%}
                 <div
+                  id="Quantity-Form-{{ section.id }}"
                   class="product-form__input product-form__quantity{% if settings.inputs_shadow_vertical_offset != 0 and settings.inputs_shadow_vertical_offset < 0 %} product-form__quantity-top{% endif %}"
                   {{ block.shopify_attributes }}
                 >
@@ -199,9 +200,9 @@
                     | item_count_for_variant: product.selected_or_first_available_variant.id
                   -%}
                   {% # theme-check-enable %}
-                  <label class="form__label" for="Quantity-{{ section.id }}">
+                  <label class="quantity__label form__label" for="Quantity-{{ section.id }}">
                     {{ 'products.product.quantity.label' | t }}
-                    <span class="quantity__rules-cart{% if cart_qty == 0 %} hidden{% endif %}">
+                    <span class="quantity__rules-cart no-js-hidden{% if cart_qty == 0 %} hidden{% endif %}">
                       <span class="loading-overlay hidden">
                         <span class="loading-overlay__spinner">
                           <svg
@@ -252,7 +253,7 @@
                       {% render 'icon-plus' %}
                     </button>
                   </quantity-input>
-                  <div class="quantity__rules caption">
+                  <div class="quantity__rules caption no-js-hidden">
                     {%- if product.selected_or_first_available_variant.quantity_rule.increment > 1 -%}
                       <span class="divider">
                         {{-
@@ -283,9 +284,9 @@
                 {% assign share_url = product.selected_variant.url | default: product.url | prepend: request.origin %}
                 {% render 'share-button', block: block, share_link: share_url %}
               {%- when 'variant_picker' -%}
-                {% render 'product-variant-picker', block: block, product: product, update_url: false %}
+                {% render 'product-variant-picker', product: product, block: block, product_form_id: product_form_id, update_url: false %}
               {%- when 'buy_buttons' -%}
-                {%- render 'buy-buttons', block: block, product: product, product_form_id: product_form_id -%}
+                {%- render 'buy-buttons', block: block, product: product, product_form_id: product_form_id, section_id: section.id -%}
               {%- when 'custom_liquid' -%}
                 {{ block.settings.custom_liquid }}
               {%- when 'rating' -%}

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -187,7 +187,10 @@
 
           {%- if shop.features.follow_on_shop? and section.settings.enable_follow_on_shop -%}
             <div class="footer__follow-on-shop">
+            {% comment %} TODO: enable theme-check once `login_button` is accepted as valid filter {% endcomment %}
+            {% # theme-check-disable %}
               {{ shop | login_button: action: 'follow' }}
+            {% # theme-check-enable %}
             </div>
           {%- endif -%}
 

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -199,6 +199,7 @@
               </div>
             {%- when 'quantity_selector' -%}
               <div
+                id="Quantity-Form-{{ section.id }}"
                 class="product-form__input product-form__quantity{% if settings.inputs_shadow_vertical_offset != 0 and settings.inputs_shadow_vertical_offset < 0 %} product-form__quantity-top{% endif %}"
                 {{ block.shopify_attributes }}
               >
@@ -206,9 +207,9 @@
                 {% # theme-check-disable %}
                 {%- assign cart_qty = cart | item_count_for_variant: product.selected_or_first_available_variant.id -%}
                 {% # theme-check-enable %}
-                <label class="form__label" for="Quantity-{{ section.id }}">
+                <label class="quantity__label form__label" for="Quantity-{{ section.id }}">
                   {{ 'products.product.quantity.label' | t }}
-                  <span class="quantity__rules-cart{% if cart_qty == 0 %} hidden{% endif %}">
+                  <span class="quantity__rules-cart no-js-hidden{% if cart_qty == 0 %} hidden{% endif %}">
                     <span class="loading-overlay hidden">
                       <span class="loading-overlay__spinner">
                         <svg
@@ -255,7 +256,7 @@
                     {% render 'icon-plus' %}
                   </button>
                 </quantity-input>
-                <div class="quantity__rules caption">
+                <div class="quantity__rules caption no-js-hidden">
                   {%- if product.selected_or_first_available_variant.quantity_rule.increment > 1 -%}
                     <span class="divider">
                       {{-
@@ -308,9 +309,9 @@
               %}
 
             {%- when 'variant_picker' -%}
-              {% render 'product-variant-picker', block: block, product: product %}
+              {% render 'product-variant-picker', product: product, block: block, product_form_id: product_form_id %}
             {%- when 'buy_buttons' -%}
-              {%- render 'buy-buttons', block: block, product: product, product_form_id: product_form_id, show_pickup_availability: true -%}
+              {%- render 'buy-buttons', block: block, product: product, product_form_id: product_form_id, section_id: section.id, show_pickup_availability: true -%}
             {%- when 'rating' -%}
               {%- if product.metafields.reviews.rating.value != blank -%}
                 {% liquid

--- a/snippets/buy-buttons.liquid
+++ b/snippets/buy-buttons.liquid
@@ -4,6 +4,7 @@
   - product: {Object} product object.
   - block: {Object} passing the block information.
   - product_form_id: {String} product form id.
+  - section_id: {String} id of section to which this snippet belongs.
   - show_pickup_availability:: {Boolean} for the pickup availability. If true the pickup availability is rendered, false - not rendered (optional).
 
   Usage:
@@ -52,6 +53,7 @@
             endif
           -%}
           <button
+            id = "ProductSubmitButton-{{ section_id }}"
             type="submit"
             name="add"
             class="product-form__submit button button--full-width {% if block.settings.show_dynamic_checkout %}button--secondary{% else %}button--primary{% endif %}"

--- a/snippets/product-variant-picker.liquid
+++ b/snippets/product-variant-picker.liquid
@@ -1,13 +1,13 @@
 {% comment %}
-    Renders product variant-picker
+  Renders product variant-picker
 
-    Accepts:
-    - product: {Object} product object.
-    - block: {Object} passing the block information.
-    - update_url: {Boolean} whether or not to update url when changing variants. If false, the url isn't updated. Default: true (optional).
-
-    Usage:
-    {% render 'product-variant-picker', block: block, product: product %}
+  Accepts:
+  - product: {Object} product object.
+  - block: {Object} passing the block information.
+  - product_form_id: {String} Id of the product form to which the variant picker is associated.
+  - update_url: {Boolean} whether or not to update url when changing variants. If false, the url isn't updated. Default: true (optional).
+  Usage:
+  {% render 'product-variant-picker', product: product, block: block, product_form_id: product_form_id %}
 {% endcomment %}
 {%- unless product.has_only_default_variant -%}
   {%- if block.settings.picker_type == 'button' -%}
@@ -16,7 +16,9 @@
       class="no-js-hidden"
       data-section="{{ section.id }}"
       data-url="{{ product.url }}"
-      {% if update_url == false %}data-update-url="false"{% endif %}
+      {% if update_url == false %}
+        data-update-url="false"
+      {% endif %}
       {{ block.shopify_attributes }}
     >
       {%- for option in product.options_with_values -%}
@@ -35,7 +37,9 @@
       class="no-js-hidden"
       data-section="{{ section.id }}"
       data-url="{{ product.url }}"
-      {% if update_url == false %}data-update-url="false"{% endif %}
+      {% if update_url == false %}
+        data-update-url="false"
+      {% endif %}
       {{ block.shopify_attributes }}
     >
       {%- for option in product.options_with_values -%}
@@ -86,9 +90,29 @@
             {% endif %}
             value="{{ variant.id }}"
           >
-            {{ variant.title }}
-            - {{ variant.price | money | strip_html }}
-            {%- if variant.available == false %} - {{ 'products.product.sold_out' | t }}{% endif %}
+            {%- liquid
+              echo variant.title
+              echo variant.price | money | strip_html | prepend: ' - '
+              if variant.available == false
+                echo 'products.product.sold_out' | t | prepend: ' - '
+              endif
+              if variant.quantity_rule.increment > 1
+                echo 'products.product.quantity.multiples_of' | t: quantity: variant.quantity_rule.increment | prepend: ' - '
+              endif
+              if variant.quantity_rule.min > 1
+                echo 'products.product.quantity.minimum_of' | t: quantity: variant.quantity_rule.min | prepend: ' - '
+              endif
+              if variant.quantity_rule.max != null
+                echo 'products.product.quantity.maximum_of' | t: quantity: variant.quantity_rule.max | prepend: ' - '
+              endif
+              # TODO: enable theme-check once `item_count_for_variant` is accepted as valid filter
+              # theme-check-disable
+              assign cart_quantity = cart | item_count_for_variant: variant.id
+              # theme-check-enable
+              if cart_quantity > 0
+                echo 'products.product.quantity.in_cart_html' | t: quantity: cart_quantity | prepend: ' - '
+              endif
+            -%}
           </option>
         {%- endfor -%}
       </select>


### PR DESCRIPTION
* Update quantity rules on product page and features product section when variant is switched

* Disable theme check for `login_button` filter. Add todo to enable theme check for that line once supported

* Update logic for fetching and displaying quantity in cart

* Format code, adjust indent

* Remove comment

* Prevent quantity rule messaging from displaying when JS is disabled. Prevents incorrect quantity rules from displaying when variant is changed

* Add quantity rules to no script variant selector

* Add missing `product_form_id` variable from variant picker snippet. Fixes no-js add to cart missing param issue

* Fix select padding to ensure text does not overlap cart icon

* Replace more granular parts of the DOM to avoid entire quantity element from being removed/added to the DOM. This prevents focus issues when tabbing

* Fix issue with cart errors when an item is removed from cart

* Refactor. Variant change and cart update now relies on same method to update product DOM for quantity rules. Rely on section rendering API instead of cart to obtain cart quantity. This avoids issues when the variant is removed from the cart.

* Use section rendering API instead of rest API to determine if add-to-cart button should be disabled on variant change

* Avoid running logic for quantity rules on product page if the quantity block is disabled

* Fix quantity rules compatibility with quick add modal.

Use correct section ID when using section rendering API to replace elements inside quick add modal

Fix issue with variant change event affecting wrong section

Fix issue with cart update triggering quantity rule update for quick add modal that has already closed

* Add variant object to variant change event data

* Remove optional chaining. Add check for possible undefined quantity