### PR TITLE
Avoid fetching quantity rules if currant variant of product does not …

### DIFF
--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -56,6 +56,7 @@ if (!customElements.get('product-info')) {
     }
 
     fetchQuantityRules() {
+      if (!this.currentVariant || !this.currentVariant.value) return;
       this.querySelector('.quantity__rules-cart .loading-overlay').classList.remove('hidden');
       fetch(`${this.dataset.url}?variant=${this.currentVariant.value}&section_id=${this.dataset.section}`).then((response) => {
         return response.text()


### PR DESCRIPTION
…exist. This can happen if the featured product section is rendered as a placeholder (blank) (#2281)