### PR TITLE
Fix mark element not getting the right color (#2286)

### DIFF
--- a/assets/component-predictive-search.css
+++ b/assets/component-predictive-search.css
@@ -190,7 +190,7 @@ predictive-search[loading]
 }
 
 .predictive-search__item-query-result mark {
-  opacity: 75%;
+  color: rgba(var(--color-foreground), 0.75);
 }
 
 .predictive-search__item-query-result mark {


### PR DESCRIPTION
* Fix mark element not getting the right color

* Update assets/component-predictive-search.css

Co-authored-by: Andrew Etchen <andrew.etchen@shopify.com>

---------

Co-authored-by: Andrew Etchen <andrew.etchen@shopify.com>